### PR TITLE
Getter for digest size used in binary digest tree.

### DIFF
--- a/tyst-api-rest-health/src/health_resources.rs
+++ b/tyst-api-rest-health/src/health_resources.rs
@@ -84,6 +84,7 @@ liveness of a microservice.
 Corresponds to the Kubernetes readiness probe.
  */
 #[utoipa::path(
+    tag = "health",
     responses(
         (status = 200, description = "Up", body = inline(HealthResponse), content_type = "application/json",),
         (status = 500, description = "Undetermined"),
@@ -107,6 +108,7 @@ to process requests.
 Corresponds to the Kubernetes readiness probe.
  */
 #[utoipa::path(
+    tag = "health",
     responses(
         (status = 200, description = "Up", body = inline(HealthResponse), content_type = "application/json",),
         (status = 500, description = "Undetermined"),
@@ -130,6 +132,7 @@ This endpoint corresponds to the Kubernetes liveness probe, which automatically
 restarts the pod if the check fails.
  */
 #[utoipa::path(
+    tag = "health",
     responses(
         (status = 200, description = "Up", body = inline(HealthResponse), content_type = "application/json",),
         (status = 500, description = "Undetermined"),
@@ -152,6 +155,7 @@ you define.
 Corresponds to the Kubernetes startup probe.
  */
 #[utoipa::path(
+    tag = "health",
     responses(
         (status = 200, description = "Up", body = inline(HealthResponse), content_type = "application/json",),
         (status = 500, description = "Undetermined"),

--- a/tyst-crypto/src/misc/binary_digest_tree.rs
+++ b/tyst-crypto/src/misc/binary_digest_tree.rs
@@ -67,9 +67,14 @@ impl BinaryDigestTreeProof {
         &self.digest_algorithm_oid
     }
 
-    /// Encoded proof.
+    /// Encoded and packed proof with root hash first.
     pub fn get_encoded_proof(&self) -> &[u8] {
         &self.encoded_proof
+    }
+
+    /// Get digest output size in bytes
+    pub fn get_digest_size_bytes(&self) -> usize {
+        self.digest_size_bytes
     }
 
     /// Get root hash.


### PR DESCRIPTION
... Also explicitly tag health-check API resources.